### PR TITLE
Add dag to stage conversion with unit tests

### DIFF
--- a/cmd/goto-dag-orchestrator/dag_orchestrator_test.go
+++ b/cmd/goto-dag-orchestrator/dag_orchestrator_test.go
@@ -14,11 +14,3 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 package main
-
-import (
-	"fmt"
-)
-
-func main() {
-	fmt.Println("dag_orchestrator")
-}

--- a/cmd/goto-dag-registerer/dag_registerer.go
+++ b/cmd/goto-dag-registerer/dag_registerer.go
@@ -39,3 +39,7 @@ func (dr DAGRegisterer) DetectCycle() error {
 	fmt.Println("check for cycle in DAG")
 	return nil
 }
+
+func main() {
+	fmt.Println("dag_registerer")
+}

--- a/cmd/goto-dag-registerer/dag_registerer_test.go
+++ b/cmd/goto-dag-registerer/dag_registerer_test.go
@@ -14,11 +14,3 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 package main
-
-import (
-	"fmt"
-)
-
-func main() {
-	fmt.Println("dag_orchestrator")
-}

--- a/cmd/goto-dag/dag.go
+++ b/cmd/goto-dag/dag.go
@@ -25,14 +25,14 @@ type DAG struct {
 	SandboxId         string
 	DAGAuthorId       string
 	ShardId           string
-	Phase             []Phase
+	Phase             []Stage
 	CreatedTime       time.Time
 	LastHeartbeatTime time.Time
 	LastRunTime       time.Time
 	TimeSLA           int64
 }
 
-type Phase struct {
+type Stage struct {
 	DAGId       string
 	PhaseId     string
 	Tasks       []Task
@@ -43,11 +43,17 @@ type Phase struct {
 
 type Task struct {
 	DAGId             string
-	PhaseId           string
+	StageId           string
 	TaskId            string
 	Query             string
 	CreatedTime       time.Time
 	LastHeartbeatTime time.Time
 	LastRunTime       time.Time
 	TimeSLA           int64
+}
+
+type RawStage struct {
+	index      int
+	stage      int
+	finalStage int
 }

--- a/cmd/goto-dag/dag_util.go
+++ b/cmd/goto-dag/dag_util.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2024 The GOTO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"errors"
+)
+
+// TopologicalSort This method takes an adjacency list of tasks with their dependencies as input
+// and creates a series of stages, where each stage can contain one or more tasks
+// All the tasks in a given stage can be executed in parallel.
+func TopologicalSort(adjList map[int][]int) ([]RawStage, error) {
+
+	topOrder := []RawStage{}
+	var stage = 0
+
+	// create a map for each node to its corresponding indegree
+	inDegree := map[int]int{}
+
+	// set values of all indegrees to 0
+	for n := range adjList {
+		inDegree[n] = 0
+	}
+
+	// for each vertex u
+	for _, u := range adjList {
+		// for each vertex v, having an edge to u
+		for _, v := range u {
+			// increment inDegree[v]
+			inDegree[v]++
+		}
+	}
+
+	// start with all vertices, where each vertex u is such that in-degree[u] = 0
+	verticesZeroIndegree := []RawStage{}
+	for u, v := range inDegree {
+		if v != 0 {
+			continue
+		}
+		verticesZeroIndegree = append(verticesZeroIndegree, RawStage{index: u, stage: stage})
+	}
+
+	for len(verticesZeroIndegree) > 0 {
+
+		// delete a vertex from VerticesWithZeroIndegree and call it deletedVertex
+		deletedVertex := verticesZeroIndegree[0]
+		verticesZeroIndegree = verticesZeroIndegree[1:]
+
+		// Add deleted vertex to the end of the topological order
+		topOrder = append(topOrder, deletedVertex)
+
+		// Increment the stage value
+		stage = stage + 1
+
+		// For each vertex v adjacent to deleted, decrement the inDegree by 1, since the edge will also be deleted.
+		for _, v := range adjList[deletedVertex.index] {
+			// Decrement inDegree[v]
+			inDegree[v]--
+
+			// if inDegree[v] = 0, then insert v into VerticesWithZeroIndegree list
+			if inDegree[v] == 0 {
+				verticesZeroIndegree = append(verticesZeroIndegree, RawStage{index: v, stage: stage})
+			}
+		}
+	}
+
+	if len(topOrder) < len(adjList) {
+		return nil, errors.New("dag-10000: cycle in the DAG")
+	}
+
+	// Fix the final stage values
+	for i, _ := range topOrder {
+		if i == 0 {
+			topOrder[i].finalStage = topOrder[i].stage
+		} else if topOrder[i].stage != topOrder[i-1].stage {
+			topOrder[i].finalStage = topOrder[i-1].finalStage + 1
+		} else {
+			topOrder[i].finalStage = topOrder[i-1].finalStage
+		}
+	}
+
+	return topOrder, nil
+}
+
+func main() {
+
+}

--- a/cmd/goto-dag/dag_util_test.go
+++ b/cmd/goto-dag/dag_util_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2024 The GOTO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTopologicalSort(t *testing.T) {
+
+	//      ------>  t2
+	//  t1 			    ------> t4
+	//      ------>  t3
+	// stage0 = t1
+	// stage1 = t2, t3
+	// stage3 = t4
+	// stage0 -> stage1 -> stage2
+
+	adjList := map[int][]int{
+		1: []int{2, 3},
+		2: []int{4},
+		3: []int{4},
+		4: []int{},
+	}
+
+	var stages, _ = TopologicalSort(adjList)
+
+	expected := []RawStage{
+		RawStage{index: 1, stage: 0, finalStage: 0},
+		RawStage{index: 2, stage: 1, finalStage: 1},
+		RawStage{index: 3, stage: 1, finalStage: 1},
+		RawStage{index: 4, stage: 3, finalStage: 2},
+	}
+
+	if !reflect.DeepEqual(expected, stages) {
+		t.Fatalf(`expected = %v, result %v ""`, expected, stages)
+	}
+
+}
+
+func TestTopologicalSortDetectCycle(t *testing.T) {
+
+	adjList := map[int][]int{
+		1: []int{4},
+		2: []int{4},
+		3: []int{2, 4, 5},
+		4: []int{6},
+		5: []int{},
+		6: []int{7},
+		7: []int{1},
+	}
+
+	var _, err = TopologicalSort(adjList)
+
+	var ErrMsg = "dag-10000: cycle in the DAG"
+
+	if err.Error() != ErrMsg {
+		t.Fatalf(`should fail with message = %q, %v, want "", error`, ErrMsg, err)
+	}
+}

--- a/cmd/goto-failure-monitor/failure_monitor_test.go
+++ b/cmd/goto-failure-monitor/failure_monitor_test.go
@@ -14,9 +14,3 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("failure_monitor")
-}

--- a/cmd/goto-metadata-store/db_client_test.go
+++ b/cmd/goto-metadata-store/db_client_test.go
@@ -14,11 +14,3 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 package main
-
-import (
-	"fmt"
-)
-
-func main() {
-	fmt.Println("db_client")
-}

--- a/cmd/goto-scheduler/scheduler_test.go
+++ b/cmd/goto-scheduler/scheduler_test.go
@@ -14,11 +14,3 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 package main
-
-import (
-	"fmt"
-)
-
-func main() {
-	fmt.Println("scheduler")
-}

--- a/cmd/goto-task-manager/task_manager_test.go
+++ b/cmd/goto-task-manager/task_manager_test.go
@@ -14,9 +14,3 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("task_manager")
-}


### PR DESCRIPTION
This PR implements a topological sort, along with converting bunch of tasks into stages, where stages can be executed serially. 
Within a given stage, there can be one or more tasks, which can be executed in parallel. 

For example: 

Given the below adjacency list 

	//       ------>  t2
	//  t1 			    ------> t4
	//       ------>  t3
	
Final stages would be 
         // stage0 = t1
	// stage1 = t2, t3
	// stage3 = t4

with the order of execution

	// stage0 -> stage1 -> stage2

     In stage0, t1 task can be executed. 
     In stage1, tasks t2 and t3 can be executed in parallel. 
     In stage2, task t4 can be executed. 

  If the algorithm detects a cycle in the DAG, it will throw an error message with relevant error code. 